### PR TITLE
Update authenticity_token

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ const readCookie = async () => {
 					name: path.basename(FILEPATH),
 					size: stat.size,
 					content_type: mime.lookup(FILEPATH),
-					authenticity_token: $('.js-upload-markdown-image').data('upload-policy-authenticity-token'),
+					authenticity_token: $('.js-upload-markdown-image').children('input[type=hidden]').attr("value"),
 					repository_id: parseInt($('meta[name="octolytics-dimension-repository_id"]').attr('content'))
 				}
 			})


### PR DESCRIPTION
It seems that github updated the tag for authenticity_token

Updating this line works again.
```
<file-attachment class="js-upload-markdown-image is-default" input="fc-issue_body" role="tabpanel" data-tab-container-no-tabstop="true" data-upload-repository-id="450256944" data-upload-policy-url="/upload/policies/assets"><input type="hidden" value="HG8jXQJx96DLWJYhRPCeC2AhorX87mGGCJzc_b7yqobixkZhvAlnrvYBSEpO4NbsDJK9VvTFMGmABuyv3ZHENQ" data-csrf="true" class="js-data-upload-policy-url-csrf" />
```

Thank you so much for coming up with this!!!